### PR TITLE
nitrous.io/ OFF 

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,4 +522,4 @@ Neste repositório estão os links interessantes de idéias, componentes e ferra
 * https://bootstrapstudio.io/
 * http://codecanyon.net/item/html-builder-frontend-version/full_screen_preview/8432859
 * http://www.layoutit.com/build
-* https://www.nitrous.io/
+


### PR DESCRIPTION
Construtor de site https://www.nitrous.io/ removido, serviço descontinuado